### PR TITLE
Release v0.6.2: Fix travel_time propagation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.2] - 2025-07-08
+
+### 🐛 Bug Fixes
+
+#### **Fixed Travel Time Propagation in Census Data Export**
+- **Fixed incorrect travel_time_minutes** in exported census CSV files
+- **Travel time now correctly propagates** from pipeline configuration to census data
+- **Previously defaulted to 15 minutes** regardless of actual isochrone travel time
+- **Now accurately reflects** the travel time used for isochrone generation (e.g., 60, 120 minutes)
+
+### 🔧 Technical Details
+
+- Added `travel_time` parameter to `integrate_census_data()` function
+- Updated `PipelineOrchestrator` to pass travel_time to census integration  
+- Modified `add_travel_distances()` to accept and use travel_time parameter
+- Maintains backward compatibility while fixing the metadata accuracy
+
 ## [0.6.1] - 2025-06-19
 
 ### 🐛 Bug Fixes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "socialmapper"
-version = "0.6.1"
+version = "0.6.2"
 description = "An open-source Python toolkit that helps understand community connections through mapping demographics and access to points of interest"
 readme = "README.md"
 requires-python = ">=3.11,<3.14"

--- a/socialmapper/distance/__init__.py
+++ b/socialmapper/distance/__init__.py
@@ -70,6 +70,7 @@ def add_travel_distances(
     n_jobs: int = -1,
     chunk_size: int = 5000,
     verbose: bool = False,
+    travel_time: int = 15,
 ) -> gpd.GeoDataFrame:
     """Calculate and add travel distances from block groups to nearest POIs.
     
@@ -81,6 +82,7 @@ def add_travel_distances(
         n_jobs: Number of parallel jobs (-1 for all cores)
         chunk_size: Chunk size for parallel processing
         verbose: If True, print detailed debug information
+        travel_time: Travel time in minutes for the analysis
 
     Returns:
         GeoDataFrame with travel distance information added
@@ -101,15 +103,15 @@ def add_travel_distances(
     # Add POI metadata
     poi_name = "unknown"
     poi_id = "unknown"
-    travel_time_minutes = 15  # Default value
+    travel_time_minutes = travel_time  # Use the parameter passed in
 
-    # Try to extract the travel time and POI info from the first POI
+    # Try to extract the POI info from the first POI
     if pois and len(pois) > 0:
         first_poi = pois[0]
         poi_id = first_poi.get("id", poi_id)
         poi_name = first_poi.get("name", first_poi.get("tags", {}).get("name", poi_name))
 
-        # Try to extract travel time from various possible sources
+        # Override travel_time only if explicitly set in POI data (for backward compatibility)
         if "travel_time" in first_poi:
             travel_time_minutes = first_poi["travel_time"]
         elif "travel_time_minutes" in first_poi:

--- a/socialmapper/pipeline/census.py
+++ b/socialmapper/pipeline/census.py
@@ -21,6 +21,7 @@ def integrate_census_data(
     poi_data: dict[str, Any],
     geographic_level: str = "block-group",
     state_abbreviations: list[str] | None = None,
+    travel_time: int = 15,
 ) -> tuple[gpd.GeoDataFrame, gpd.GeoDataFrame, list[str]]:
     """Integrate census data with isochrones.
 
@@ -30,6 +31,8 @@ def integrate_census_data(
         api_key: Census API key
         poi_data: POI data for distance calculations
         geographic_level: Geographic unit ('block-group' or 'zcta')
+        state_abbreviations: List of state abbreviations
+        travel_time: Travel time in minutes for the isochrones
 
     Returns:
         Tuple of (geographic_units_gdf, census_data_gdf, census_codes)
@@ -152,7 +155,7 @@ def integrate_census_data(
     # Calculate travel distances in memory
     try:
         units_with_distances = add_travel_distances(
-            block_groups_gdf=geographic_units_gdf, poi_data=poi_data
+            block_groups_gdf=geographic_units_gdf, poi_data=poi_data, travel_time=travel_time
         )
     except Exception as e:
         logger.error(f"Error in add_travel_distances: {type(e).__name__}: {e}")

--- a/socialmapper/pipeline/orchestrator.py
+++ b/socialmapper/pipeline/orchestrator.py
@@ -221,6 +221,7 @@ class PipelineOrchestrator:
             poi_data=poi_data,
             geographic_level=self.config.geographic_level,
             state_abbreviations=state_abbreviations,
+            travel_time=self.config.travel_time,
         )
 
     def _export_outputs(self):


### PR DESCRIPTION
## 🐛 Bug Fix Release

This release fixes the travel_time propagation bug in census data export.

### Changes
- Fixed incorrect `travel_time_minutes` in exported census CSV files
- Travel time now correctly propagates from pipeline configuration to census data
- Previously defaulted to 15 minutes regardless of actual isochrone travel time
- Now accurately reflects the travel time used for isochrone generation (e.g., 60, 120 minutes)

### Technical Details
- Added `travel_time` parameter to `integrate_census_data()` function
- Updated `PipelineOrchestrator` to pass travel_time to census integration  
- Modified `add_travel_distances()` to accept and use travel_time parameter
- Maintains backward compatibility while fixing the metadata accuracy

### Release Status
- ✅ Package published to PyPI: https://pypi.org/project/socialmapper/0.6.2/
- ✅ Git tag created: v0.6.2
- ✅ Tests passing